### PR TITLE
fix: 输出目录改为仓库内相对路径，去掉写死的个人目录

### DIFF
--- a/TraeCheckin.Launcher/TraeCheckin.Launcher.csproj
+++ b/TraeCheckin.Launcher/TraeCheckin.Launcher.csproj
@@ -16,8 +16,9 @@
     <EnableCompressionInSingleFile>true</EnableCompressionInSingleFile>
     <InvariantGlobalization>true</InvariantGlobalization>
     <ApplicationIcon>..\app.ico</ApplicationIcon>
-    <!-- 统一构建产物输出目录：启动器单文件发布到这里，与主程序同目录 -->
-    <PublishDir>C:\Users\星梦\Desktop\插件开发\TraeCheckin开发\</PublishDir>
+    <!-- 统一构建产物输出目录：启动器单文件发布到仓库根 bin\TraeCheckin，与主程序同目录。
+         使用仓库内相对路径，避免写死到个人账号目录。 -->
+    <PublishDir>..\bin\TraeCheckin\</PublishDir>
   </PropertyGroup>
 
 </Project>

--- a/TraeCheckin.csproj
+++ b/TraeCheckin.csproj
@@ -11,8 +11,9 @@
     <Version>1.4.4</Version>
     <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
     <ApplicationIcon>app.ico</ApplicationIcon>
-    <!-- 统一构建产物输出目录（主程序 + 启动器都输出到这里） -->
-    <OutputPath>C:\Users\星梦\Desktop\插件开发\TraeCheckin开发\</OutputPath>
+    <!-- 统一构建产物输出目录（主程序 + 启动器都输出到这里）。
+         使用仓库内相对路径，避免写死到个人账号目录。 -->
+    <OutputPath>bin\TraeCheckin\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
## 问题
两个 csproj 的构建输出路径写死为 C:\Users\星梦\Desktop\插件开发\TraeCheckin开发\，换机器后该目录不存在会导致构建失败：

- TraeCheckin.csproj — \OutputPath\
- TraeCheckin.Launcher/TraeCheckin.Launcher.csproj — \PublishDir\

## 修复
改为仓库内相对路径 in\TraeCheckin\（启动器通过 \..\bin\TraeCheckin\ 与主程序输出到同一目录），机器无关、可移植。

## 测试
- 本地 dotnet build -c Release 主工程 + dotnet publish -c Release -r win-x64 启动器均成功。
- 输出结构与既有 v1.4.3 发布包一致，已本地打包 TraeCheckin-v1.4.4-win-x64.zip。