### PR TITLE
chore: 启动器版本号同步到 1.5.1

### DIFF
--- a/TraeCheckin.Launcher/TraeCheckin.Launcher.csproj
+++ b/TraeCheckin.Launcher/TraeCheckin.Launcher.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
     <AssemblyName>TraeCheckin.Launcher</AssemblyName>
     <RootNamespace>TraeCheckin.Launcher</RootNamespace>
-    <Version>1.4.5</Version>
+    <Version>1.5.1</Version>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
     <PublishSingleFile>true</PublishSingleFile>


### PR DESCRIPTION
将 TraeCheckin.Launcher.csproj 版本号从 1.4.5 同步到 1.5.1，与主程序(v1.5.1)及发布 tag 保持一致。